### PR TITLE
Change vue-router to History Mode with redirect breadcrumb support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,9 +39,9 @@ pipeline {
     SOURCE_REPO_URL = "https://github.com/${REPO_OWNER}/${REPO_NAME}.git"
 
     // ENV_HOST is the full domain without the path (ie. 'appname-dev.pathfinder.gov.bc.ca')
-    DEV_HOST = "${REPO_NAME}-dev.${APP_DOMAIN}"
-    TEST_HOST = "${REPO_NAME}-test.${APP_DOMAIN}"
-    PROD_HOST = "${REPO_NAME}.${APP_DOMAIN}"
+    DEV_HOST = "${APP_NAME}-dev.${APP_DOMAIN}"
+    TEST_HOST = "${APP_NAME}-test.${APP_DOMAIN}"
+    PROD_HOST = "${APP_NAME}.${APP_DOMAIN}"
     // PATH_ROOT will be appended to ENV_HOST
     PATH_ROOT = "/${JOB_NAME.equalsIgnoreCase('master') ? 'app' : JOB_NAME}"
 

--- a/Jenkinsfile.cicd
+++ b/Jenkinsfile.cicd
@@ -39,9 +39,9 @@ pipeline {
     SOURCE_REPO_URL = "https://github.com/${REPO_OWNER}/${REPO_NAME}.git"
 
     // ENV_HOST is the full domain without the path (ie. 'appname-dev.pathfinder.gov.bc.ca')
-    DEV_HOST = "${REPO_NAME}-dev.${APP_DOMAIN}"
-    TEST_HOST = "${REPO_NAME}-test.${APP_DOMAIN}"
-    PROD_HOST = "${REPO_NAME}.${APP_DOMAIN}"
+    DEV_HOST = "${APP_NAME}-dev.${APP_DOMAIN}"
+    TEST_HOST = "${APP_NAME}-test.${APP_DOMAIN}"
+    PROD_HOST = "${APP_NAME}.${APP_DOMAIN}"
     // PATH_ROOT will be appended to ENV_HOST
     PATH_ROOT = "/${JOB_NAME.equalsIgnoreCase('master') ? 'app' : JOB_NAME}"
 

--- a/app/app.js
+++ b/app/app.js
@@ -5,6 +5,7 @@ const log = require('npmlog');
 const morgan = require('morgan');
 const path = require('path');
 const Problem = require('api-problem');
+const querystring = require('querystring');
 
 const keycloak = require('./src/components/keycloak');
 const v1Router = require('./src/routes/v1');
@@ -84,8 +85,9 @@ app.use((req, res) => {
       detail: req.originalUrl
     }).send(res);
   } else {
-    // Redirect any non-API requests to static frontend
-    res.redirect(staticFilesPath);
+    // Redirect any non-API requests to static frontend with redirect breadcrumb
+    const query = querystring.stringify({ r: req.path });
+    res.redirect(`${staticFilesPath}/?${query}`);
   }
 });
 

--- a/app/app.js
+++ b/app/app.js
@@ -52,8 +52,8 @@ apiRouter.get('/api', (_req, res) => {
 });
 
 // Host API endpoints
-apiRouter.use(`${config.get('server.apiPath')}`, v1Router);
-app.use(`${config.get('server.basePath')}`, apiRouter);
+apiRouter.use(config.get('server.apiPath'), v1Router);
+app.use(config.get('server.basePath'), apiRouter);
 
 // Host the static frontend assets
 const staticFilesPath = config.get('frontend.basePath');

--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -1,7 +1,6 @@
 <template>
   <v-app>
     <BCGovHeader />
-    <BCGovNavBar />
 
     <v-content>
       <transition name="component-fade" mode="out-in">
@@ -16,14 +15,12 @@
 <script>
 import BCGovHeader from '@/components/bcgov/BCGovHeader.vue';
 import BCGovFooter from '@/components/bcgov/BCGovFooter.vue';
-import BCGovNavBar from '@/components/bcgov/BCGovNavBar.vue';
 
 export default {
   name: 'App',
   components: {
     BCGovHeader,
-    BCGovFooter,
-    BCGovNavBar
+    BCGovFooter
   }
 };
 </script>

--- a/app/frontend/src/components/base/BaseAuthButton.vue
+++ b/app/frontend/src/components/base/BaseAuthButton.vue
@@ -33,10 +33,7 @@ export default {
     logout() {
       if (this.keycloakReady) {
         window.location.replace(
-          this.createLogoutUrl({
-            idpHint: 'idir',
-            redirectUri: location.origin + location.pathname
-          })
+          this.createLogoutUrl({ idpHint: 'idir' })
         );
       }
     }

--- a/app/frontend/src/components/bcgov/BCGovHeader.vue
+++ b/app/frontend/src/components/bcgov/BCGovHeader.vue
@@ -17,7 +17,9 @@ export default {
   name: 'BCGovHeader',
   computed: {
     appTitle() {
-      return process.env.VUE_APP_TITLE;
+      return this.$route && this.$route.meta && this.$route.meta.title
+        ? this.$route.meta.title
+        : process.env.VUE_APP_TITLE;
     }
   }
 };

--- a/app/frontend/src/components/bcgov/BCGovNavBar.vue
+++ b/app/frontend/src/components/bcgov/BCGovNavBar.vue
@@ -6,6 +6,9 @@
           <router-link :to="{ name: 'Home' }">Home</router-link>
         </li>
         <li>
+          <router-link :to="{ name: 'MinesAttestationsForm' }">Mines Attestations</router-link>
+        </li>
+        <li>
           <router-link :to="{ name: 'Secure' }">Secure</router-link>
         </li>
       </ul>

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -8,7 +8,7 @@ import Vue from 'vue';
 
 import App from '@/App.vue';
 import auth from '@/store/modules/auth.js';
-import router from '@/router';
+import getRouter from '@/router';
 import store from '@/store';
 import VueKeycloakJs from '@/plugins/keycloak';
 import vuetify from '@/plugins/vuetify';
@@ -31,13 +31,14 @@ loadConfig();
 /**
  * @function initializeApp
  * Initializes and mounts the Vue instance
- * @param {boolean} kcSuccess is Keycloak initialized successfully?
+ * @param {boolean} [kcSuccess=false] is Keycloak initialized successfully?
+ * @param {string} [basepath='/'] base server path
  */
-function initializeApp(kcSuccess = false) {
+function initializeApp(kcSuccess = false, basePath = '/') {
   if (kcSuccess && !store.hasModule('auth')) store.registerModule('auth', auth);
 
   new Vue({
-    router,
+    router: getRouter(basePath),
     store,
     vuetify,
     render: h => h(App)
@@ -93,7 +94,7 @@ function loadKeycloak(config) {
       url: config.keycloak.serverUrl
     },
     onReady: () => {
-      initializeApp(true);
+      initializeApp(true, config.basePath);
     },
     onInitError: error => {
       console.error('Keycloak failed to initialize'); // eslint-disable-line no-console

--- a/app/frontend/src/router/index.js
+++ b/app/frontend/src/router/index.js
@@ -4,6 +4,8 @@ import VueRouter from 'vue-router';
 
 Vue.use(VueRouter);
 
+let isFirstTransition = true;
+
 /**
  * Constructs and returns a Vue Router object
  * @param {string} [basePath] the base server path
@@ -61,12 +63,14 @@ export default function getRouter(basePath = '/') {
       window.location.replace(loginUrl);
     } else {
       document.title = `${process.env.VUE_APP_TITLE} | ${to.meta.title}`;
-      if (to.query.r) next({ path: to.query.r.replace(basePath, '') });
-      else next();
+      if (to.query.r && isFirstTransition) {
+        next({ path: to.query.r.replace(basePath, '')});
+      } else next();
     }
   });
 
   router.afterEach(() => {
+    isFirstTransition = false;
     NProgress.done();
   });
 

--- a/app/frontend/src/router/index.js
+++ b/app/frontend/src/router/index.js
@@ -49,7 +49,7 @@ export default function getRouter(basePath = '/') {
     ]
   });
 
-  router.beforeEach((to, from, next) => {
+  router.beforeEach((to, _from, next) => {
     NProgress.start();
     if (to.matched.some(route => route.meta.requiresAuth)
       && router.app.$keycloak
@@ -64,8 +64,9 @@ export default function getRouter(basePath = '/') {
     } else {
       document.title = `${process.env.VUE_APP_TITLE} | ${to.meta.title}`;
       if (to.query.r && isFirstTransition) {
-        next({ path: to.query.r.replace(basePath, '')});
-      } else next();
+        router.replace({ path: to.query.r.replace(basePath, '') });
+      }
+      next();
     }
   });
 

--- a/app/frontend/src/router/index.js
+++ b/app/frontend/src/router/index.js
@@ -8,7 +8,7 @@ let isFirstTransition = true;
 
 /**
  * Constructs and returns a Vue Router object
- * @param {string} [basePath] the base server path
+ * @param {string} [basePath='/'] the base server path
  * @returns {object} a Vue Router object
  */
 export default function getRouter(basePath = '/') {
@@ -24,9 +24,29 @@ export default function getRouter(basePath = '/') {
         path: '/home',
         name: 'Home',
         component: () => import(/* webpackChunkName: "home" */ '@/views/Home.vue'),
-        meta: {
-          title: 'Home'
-        }
+      },
+      {
+        path: '/industrialcamps',
+        component: () => import(/* webpackChunkName: "mines-attestations" */ '@/views/MinesAttestations.vue'),
+        children: [
+          {
+            path: '',
+            name: 'MinesAttestationsForm',
+            component: () => import(/* webpackChunkName: "mines-attestations-form" */ '@/views/minesattestations/Root.vue'),
+            meta: {
+              title: 'Industrial Camps'
+            }
+          },
+          {
+            path: 'admin',
+            name: 'MinesAttestationsAdmin',
+            component: () => import(/* webpackChunkName: "mines-attestations-admin" */ '@/views/minesattestations/Admin.vue'),
+            meta: {
+              requiresAuth: true,
+              title: 'Industrial Camps Admin'
+            }
+          }
+        ]
       },
       {
         path: '/secure',
@@ -42,9 +62,6 @@ export default function getRouter(basePath = '/') {
         alias: '*',
         name: 'NotFound',
         component: () => import(/* webpackChunkName: "not-found" */ '@/views/NotFound.vue'),
-        meta: {
-          title: '404'
-        }
       }
     ]
   });
@@ -62,7 +79,7 @@ export default function getRouter(basePath = '/') {
       });
       window.location.replace(loginUrl);
     } else {
-      document.title = `${process.env.VUE_APP_TITLE} | ${to.meta.title}`;
+      document.title = to.meta.title ? to.meta.title : process.env.VUE_APP_TITLE;
       if (to.query.r && isFirstTransition) {
         router.replace({ path: to.query.r.replace(basePath, '') });
       }

--- a/app/frontend/src/router/index.js
+++ b/app/frontend/src/router/index.js
@@ -4,49 +4,62 @@ import VueRouter from 'vue-router';
 
 Vue.use(VueRouter);
 
-const router = new VueRouter({
-  routes: [
-    {
-      path: '/',
-      name: 'Home',
-      component: () => import(/* webpackChunkName: "home" */ '@/views/Home.vue')
-    },
-    {
-      path: '/secure',
-      name: 'Secure',
-      component: () => import(/* webpackChunkName: "secure" */ '@/views/Secure.vue'),
-      meta: {
-        requiresAuth: true
+/**
+ * Constructs and returns a Vue Router object
+ * @param {string} [basePath] the base server path
+ * @returns {object} a Vue Router object
+ */
+export default function getRouter(basePath = '/') {
+  const router = new VueRouter({
+    base: basePath,
+    mode: 'history',
+    routes: [
+      {
+        path: '/',
+        redirect: { name: 'Home' }
+      },
+      {
+        path: '/home',
+        name: 'Home',
+        component: () => import(/* webpackChunkName: "home" */ '@/views/Home.vue')
+      },
+      {
+        path: '/secure',
+        name: 'Secure',
+        component: () => import(/* webpackChunkName: "secure" */ '@/views/Secure.vue'),
+        meta: {
+          requiresAuth: true
+        }
+      },
+      {
+        path: '/404',
+        alias: '*',
+        name: 'NotFound',
+        component: () => import(/* webpackChunkName: "not-found" */ '@/views/NotFound.vue')
       }
-    },
-    {
-      path: '/404',
-      alias: '*',
-      name: 'NotFound',
-      component: () => import(/* webpackChunkName: "not-found" */ '@/views/NotFound.vue')
+    ]
+  });
+
+  router.beforeEach((to, _from, next) => {
+    NProgress.start();
+    if (to.matched.some(route => route.meta.requiresAuth)
+      && router.app.$keycloak
+      && router.app.$keycloak.ready
+      && !router.app.$keycloak.authenticated) {
+      const redirect = location.origin + basePath + to.path;
+      const loginUrl = router.app.$keycloak.createLoginUrl({
+        idpHint: 'idir',
+        redirectUri: redirect
+      });
+      window.location.replace(loginUrl);
+    } else {
+      next();
     }
-  ]
-});
+  });
 
-router.beforeEach((to, _from, next) => {
-  NProgress.start();
-  if (to.matched.some(route => route.meta.requiresAuth)
-    && router.app.$keycloak
-    && router.app.$keycloak.ready
-    && !router.app.$keycloak.authenticated) {
-    const redirect = location.origin + location.pathname + '#' + to.path;
-    const loginUrl = router.app.$keycloak.createLoginUrl({
-      idpHint: 'idir',
-      redirectUri: redirect
-    });
-    window.location.replace(loginUrl);
-  } else {
-    next();
-  }
-});
+  router.afterEach(() => {
+    NProgress.done();
+  });
 
-router.afterEach(() => {
-  NProgress.done();
-});
-
-export default router;
+  return router;
+}

--- a/app/frontend/src/router/index.js
+++ b/app/frontend/src/router/index.js
@@ -40,7 +40,7 @@ export default function getRouter(basePath = '/') {
     ]
   });
 
-  router.beforeEach((to, _from, next) => {
+  router.beforeEach((to, from, next) => {
     NProgress.start();
     if (to.matched.some(route => route.meta.requiresAuth)
       && router.app.$keycloak
@@ -53,7 +53,8 @@ export default function getRouter(basePath = '/') {
       });
       window.location.replace(loginUrl);
     } else {
-      next();
+      if (to.query.r) next({ path: to.query.r.replace(basePath, '') });
+      else next();
     }
   });
 

--- a/app/frontend/src/router/index.js
+++ b/app/frontend/src/router/index.js
@@ -26,7 +26,7 @@ export default function getRouter(basePath = '/') {
         component: () => import(/* webpackChunkName: "home" */ '@/views/Home.vue'),
       },
       {
-        path: '/industrialcamps',
+        path: '/minesattestations',
         component: () => import(/* webpackChunkName: "mines-attestations" */ '@/views/MinesAttestations.vue'),
         children: [
           {
@@ -53,8 +53,7 @@ export default function getRouter(basePath = '/') {
         name: 'Secure',
         component: () => import(/* webpackChunkName: "secure" */ '@/views/Secure.vue'),
         meta: {
-          requiresAuth: true,
-          title: 'Secure'
+          requiresAuth: true
         }
       },
       {

--- a/app/frontend/src/router/index.js
+++ b/app/frontend/src/router/index.js
@@ -21,21 +21,28 @@ export default function getRouter(basePath = '/') {
       {
         path: '/home',
         name: 'Home',
-        component: () => import(/* webpackChunkName: "home" */ '@/views/Home.vue')
+        component: () => import(/* webpackChunkName: "home" */ '@/views/Home.vue'),
+        meta: {
+          title: 'Home'
+        }
       },
       {
         path: '/secure',
         name: 'Secure',
         component: () => import(/* webpackChunkName: "secure" */ '@/views/Secure.vue'),
         meta: {
-          requiresAuth: true
+          requiresAuth: true,
+          title: 'Secure'
         }
       },
       {
         path: '/404',
         alias: '*',
         name: 'NotFound',
-        component: () => import(/* webpackChunkName: "not-found" */ '@/views/NotFound.vue')
+        component: () => import(/* webpackChunkName: "not-found" */ '@/views/NotFound.vue'),
+        meta: {
+          title: '404'
+        }
       }
     ]
   });
@@ -53,6 +60,7 @@ export default function getRouter(basePath = '/') {
       });
       window.location.replace(loginUrl);
     } else {
+      document.title = `${process.env.VUE_APP_TITLE} | ${to.meta.title}`;
       if (to.query.r) next({ path: to.query.r.replace(basePath, '') });
       else next();
     }

--- a/app/frontend/src/views/Home.vue
+++ b/app/frontend/src/views/Home.vue
@@ -1,15 +1,21 @@
 <template>
-  <v-container>
-    <h1 class="my-6 text-center">Welcome to Vuetify</h1>
-    <HelloWorld />
-  </v-container>
+  <div>
+    <BCGovNavBar />
+    <v-container>
+      <h1 class="my-6 text-center">Welcome to Vuetify</h1>
+      <HelloWorld />
+    </v-container>
+  </div>
 </template>
 
 <script>
+import BCGovNavBar from '@/components/bcgov/BCGovNavBar.vue';
 import HelloWorld from '@/components/HelloWorld.vue';
+
 export default {
   name: 'Home',
   components: {
+    BCGovNavBar,
     HelloWorld
   }
 };

--- a/app/frontend/src/views/MinesAttestations.vue
+++ b/app/frontend/src/views/MinesAttestations.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-container>
+    <transition name="component-fade" mode="out-in">
+      <router-view />
+    </transition>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: 'MinesAttestations'
+};
+</script>
+
+<style scoped>
+.component-fade-enter-active,
+.component-fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+.component-fade-enter,
+.component-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/app/frontend/src/views/minesattestations/Admin.vue
+++ b/app/frontend/src/views/minesattestations/Admin.vue
@@ -1,0 +1,13 @@
+<template>
+  <v-container>
+    <BaseSecure>
+      <h1 class="my-6 text-center">Admin</h1>
+    </BaseSecure>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: 'IndustrialCampsAdmin'
+};
+</script>

--- a/app/frontend/src/views/minesattestations/Admin.vue
+++ b/app/frontend/src/views/minesattestations/Admin.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'IndustrialCampsAdmin'
+  name: 'MinesAttestationsAdmin'
 };
 </script>

--- a/app/frontend/src/views/minesattestations/Root.vue
+++ b/app/frontend/src/views/minesattestations/Root.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'IndustrialCampsRoot'
+  name: 'MinesAttestationsRoot'
 };
 </script>

--- a/app/frontend/src/views/minesattestations/Root.vue
+++ b/app/frontend/src/views/minesattestations/Root.vue
@@ -1,0 +1,11 @@
+<template>
+  <v-container>
+    <h1 class="my-6 text-center">Industrial Camps Form</h1>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: 'IndustrialCampsRoot'
+};
+</script>

--- a/app/frontend/tests/unit/components/bcgov/BCGovHeader.spec.js
+++ b/app/frontend/tests/unit/components/bcgov/BCGovHeader.spec.js
@@ -1,21 +1,20 @@
-import { shallowMount } from '@vue/test-utils';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuetify from 'vuetify';
 
+import getRouter from '@/router';
 import BCGovHeader from '@/components/bcgov/BCGovHeader.vue';
 
+const localVue = createLocalVue();
+localVue.use(getRouter());
+localVue.use(Vuetify);
+
 describe('BCGovHeader.vue', () => {
-  let vuetify;
-
-  beforeEach(() => {
-    vuetify = new Vuetify();
-  });
-
   it('renders', () => {
     const wrapper = shallowMount(BCGovHeader, {
-      vuetify,
+      localVue,
       stubs: ['BaseAuthButton']
     });
 
-    expect(wrapper.text()).toMatch('');
+    expect(wrapper.html()).toMatch('');
   });
 });

--- a/app/frontend/tests/unit/router/index.spec.js
+++ b/app/frontend/tests/unit/router/index.spec.js
@@ -1,10 +1,11 @@
-import router from '@/router';
+import getRouter from '@/router';
 
 describe('Router', () => {
+  const router = getRouter();
   const routes = router.options.routes;
 
   it('has the correct number of routes', () => {
-    expect(routes).toHaveLength(3);
+    expect(routes).toHaveLength(4);
   });
 
   it('has the expected routes', () => {

--- a/app/frontend/tests/unit/router/index.spec.js
+++ b/app/frontend/tests/unit/router/index.spec.js
@@ -5,7 +5,7 @@ describe('Router', () => {
   const routes = router.options.routes;
 
   it('has the correct number of routes', () => {
-    expect(routes).toHaveLength(4);
+    expect(routes).toHaveLength(5);
   });
 
   it('has the expected routes', () => {

--- a/app/frontend/tests/unit/views/Home.spec.js
+++ b/app/frontend/tests/unit/views/Home.spec.js
@@ -13,7 +13,7 @@ describe('Home.vue', () => {
   it('renders', () => {
     const wrapper = shallowMount(Home, {
       vuetify,
-      stubs: ['HelloWorld']
+      stubs: ['BCGovNavBar', 'HelloWorld']
     });
 
     expect(wrapper.html()).toMatch('Welcome to Vuetify');

--- a/app/frontend/tests/unit/views/MinesAttestations.spec.js
+++ b/app/frontend/tests/unit/views/MinesAttestations.spec.js
@@ -1,0 +1,17 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import Vuetify from 'vuetify';
+
+import getRouter from '@/router';
+import MinesAttestations from '@/views/MinesAttestations.vue';
+
+const localVue = createLocalVue();
+localVue.use(getRouter());
+localVue.use(Vuetify);
+
+describe('MinesAttestations.vue', () => {
+  it('renders', () => {
+    const wrapper = shallowMount(MinesAttestations, { localVue });
+
+    expect(wrapper.html()).toMatch('router-view');
+  });
+});

--- a/app/frontend/tests/unit/views/minesattestations/Admin.spec.js
+++ b/app/frontend/tests/unit/views/minesattestations/Admin.spec.js
@@ -1,0 +1,15 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import Vuetify from 'vuetify';
+
+import Admin from '@/views/minesattestations/Admin.vue';
+
+const localVue = createLocalVue();
+localVue.use(Vuetify);
+
+describe('Admin.vue', () => {
+  it('renders', () => {
+    const wrapper = shallowMount(Admin, { localVue, stubs: ['BaseSecure'] });
+
+    expect(wrapper.html()).toMatch('Admin');
+  });
+});

--- a/app/frontend/tests/unit/views/minesattestations/Root.spec.js
+++ b/app/frontend/tests/unit/views/minesattestations/Root.spec.js
@@ -1,0 +1,15 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import Vuetify from 'vuetify';
+
+import Root from '@/views/minesattestations/Root.vue';
+
+const localVue = createLocalVue();
+localVue.use(Vuetify);
+
+describe('Root.vue', () => {
+  it('renders', () => {
+    const wrapper = shallowMount(Root, { localVue });
+
+    expect(wrapper.html()).toMatch('Industrial Camps Form');
+  });
+});

--- a/app/frontend/vue.config.js
+++ b/app/frontend/vue.config.js
@@ -1,10 +1,6 @@
 process.env.VUE_APP_VERSION = require('./package.json').version;
 
-const proxyConfig = {
-  target: 'http://localhost:8080',
-  ws: true,
-  changeOrigin: true
-};
+const proxyTarget = 'http://localhost:8080';
 
 module.exports = {
   publicPath: process.env.FRONTEND_BASEPATH ? process.env.FRONTEND_BASEPATH : '/app',
@@ -13,8 +9,15 @@ module.exports = {
   ],
   devServer: {
     proxy: {
-      '/api': proxyConfig,
-      '/config': proxyConfig
+      '/api': {
+        target: proxyTarget,
+        ws: true,
+        changeOrigin: true
+      },
+      '/config': {
+        target: proxyTarget,
+        pathRewrite: {'^/app' : ''}
+      }
     }
   }
 };

--- a/app/frontend/vue.config.js
+++ b/app/frontend/vue.config.js
@@ -7,7 +7,7 @@ const proxyConfig = {
 };
 
 module.exports = {
-  publicPath: '/app',
+  publicPath: process.env.FRONTEND_BASEPATH ? process.env.FRONTEND_BASEPATH : '/app',
   'transpileDependencies': [
     'vuetify'
   ],

--- a/app/frontend/vue.config.js
+++ b/app/frontend/vue.config.js
@@ -7,14 +7,14 @@ const proxyConfig = {
 };
 
 module.exports = {
-  publicPath: './',
+  publicPath: '/app',
   'transpileDependencies': [
     'vuetify'
   ],
   devServer: {
     proxy: {
-      '/config': proxyConfig,
-      '^/app/api': proxyConfig
+      '/api': proxyConfig,
+      '/config': proxyConfig
     }
   }
 };

--- a/app/nodemon.json
+++ b/app/nodemon.json
@@ -2,7 +2,7 @@
   "ignore": [
     "frontend/node_modules",
     "frontend/src",
-    "frontend/test",
+    "frontend/tests",
     "node_modules/**/node_modules",
     "test"
   ]

--- a/openshift/app.bc.yaml
+++ b/openshift/app.bc.yaml
@@ -53,6 +53,9 @@ objects:
           CMD ["npm", "run", "start"]
       strategy:
         dockerStrategy:
+          env:
+            - name: FRONTEND_BASEPATH
+              value: "${ROUTE_PATH}"
           from:
             kind: DockerImage
             name: "mhart/alpine-node:12"
@@ -62,6 +65,10 @@ parameters:
   - name: REPO_NAME
     description: Application repository name
     displayName: Repository Name
+    required: true
+  - name: ROUTE_PATH
+    description: Configure the route path (ex. /pr-5 or /app), also used for FRONTEND_BASEPATH
+    displayName: Route path
     required: true
   - name: JOB_NAME
     description: Job identifier (i.e. 'pr-5' OR 'master')

--- a/openshift/commonPipeline.groovy
+++ b/openshift/commonPipeline.groovy
@@ -64,6 +64,7 @@ def runStageBuild() {
         def bcApp = openshift.process('-f',
           'openshift/app.bc.yaml',
           "REPO_NAME=${REPO_NAME}",
+          "ROUTE_PATH=${pathEnv}",
           "JOB_NAME=${JOB_NAME}",
           "SOURCE_REPO_URL=${SOURCE_REPO_URL}",
           "SOURCE_REPO_REF=${SOURCE_REPO_REF}"

--- a/openshift/commonPipeline.groovy
+++ b/openshift/commonPipeline.groovy
@@ -64,7 +64,7 @@ def runStageBuild() {
         def bcApp = openshift.process('-f',
           'openshift/app.bc.yaml',
           "REPO_NAME=${REPO_NAME}",
-          "ROUTE_PATH=${pathEnv}",
+          "ROUTE_PATH=${PATH_ROOT}",
           "JOB_NAME=${JOB_NAME}",
           "SOURCE_REPO_URL=${SOURCE_REPO_URL}",
           "SOURCE_REPO_REF=${SOURCE_REPO_REF}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR changes vue-router from hash mode to history mode. This will allow users to navigate to all defined subpaths correctly, and potentially enable DNS 302 redirects.
**Other changes**
- Modify subdomain to be comfort-<env>
- Add meta.title support to document.title history
- Add dynamic build-time publicPath support
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->