### PR TITLE
Submissions Query Results... but smaller

### DIFF
--- a/app/src/forms/minesattestations/middleware/searchParameters.js
+++ b/app/src/forms/minesattestations/middleware/searchParameters.js
@@ -34,6 +34,16 @@ const verifyInt = (obj, param, result, errors) => {
   }
 };
 
+const verifyBoolean = (obj, param, result, errors) => {
+  if (obj[param]) {
+    if (isString(obj[param]) && ['true','false'].includes(obj[param].toLowerCase())) {
+      result[param] = 'true' === obj[param].toLowerCase();
+    } else {
+      errors.push(`${param} parameter must be a boolean`);
+    }
+  }
+};
+
 const submissionSearch = async (req, res, next) => {
   try {
     const errors = [];
@@ -42,6 +52,7 @@ const submissionSearch = async (req, res, next) => {
     if (req.query) {
       verifyInt(req.query, 'version', result, errors);
       ['confirmationId', 'business', 'city'].forEach(p => verifyString(req.query, p, result, errors));
+      verifyBoolean(req.query, 'tiny', result, errors);
     }
 
     if (errors.length) {

--- a/app/src/forms/minesattestations/models/searchParameters.js
+++ b/app/src/forms/minesattestations/models/searchParameters.js
@@ -4,6 +4,7 @@ class SubmissionSearch {
     this.confirmationId = undefined;
     this.business = undefined;
     this.city = undefined;
+    this.tiny = undefined;
   }
 }
 

--- a/app/src/forms/minesattestations/models/submission.js
+++ b/app/src/forms/minesattestations/models/submission.js
@@ -35,7 +35,7 @@ class Submission extends UpdatedAt(Model) {
   static get modifiers () {
     return {
       orderDescending(builder) {
-        builder.orderBy('updatedAt', 'desc');
+        builder.orderBy('createdAt', 'desc');
       },
       filterVersion(query, value) {
         if (value) {
@@ -158,7 +158,15 @@ class SubmissionStatus extends UpdatedAt(Model) {
           from: `${SUBMISSION}_status.submissionStatusId`,
           to: `${PREFIX}_note.submissionStatusId`
         }
-      }
+      },
+      statusCode: {
+        relation: Model.HasOneRelation,
+        modelClass: Models.StatusCode,
+        join: {
+          from: `${SUBMISSION}_status.code`,
+          to: `${PREFIX}_status_code.code`
+        }
+      },
     };
   }
 }


### PR DESCRIPTION
Allow searching submissions to return a very reduced set of data... some would say tiny.
YOu can still pass in all the other filters: city, business, version, confirmationId, but now specify tiny if you want the tiny set.

GET /submissions?tiny=true
`{
        "submissionId": "6abc0e34-37b8-449a-8175-24407152c981",
        "formVersionId": 1,
        "confirmationId": "6abc0e34",
        "createdAt": "2020-05-16T22:16:07.333Z",
        "businessName": "Rad Biz",
        "city": "Victoria, BC",
        "status": "Submitted"
    }`

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->