### PR TITLE
Authorization.

### DIFF
--- a/app/src/components/keycloak.js
+++ b/app/src/components/keycloak.js
@@ -11,5 +11,5 @@ module.exports = new Keycloak({}, {
   serverUrl: config.get('server.keycloak.serverUrl'),
   'ssl-required': 'external',
   'use-resource-role-mappings': true,
-  'verify-token-audience': false
+  'verify-token-audience': true
 });

--- a/app/src/forms/form/middleware/auth.js
+++ b/app/src/forms/form/middleware/auth.js
@@ -1,6 +1,6 @@
 const keycloak = require('../../../../src/components/keycloak');
 
-const RESOURCE_ACCESS = `comfort-${require('../constants').SLUG}`;
+const RESOURCE_ACCESS = 'comfort';
 
 const DEFAULT_USER = {username: 'public', name: 'public', email: undefined};
 
@@ -38,7 +38,7 @@ const currentUser = async (req, res, next) => {
 /**
  * Return keycloak.protect middleware.
  * Keycloak will authorize if user has ONE of the specified roles in roles parameter.
- * Check against resource_access for comfort-client, where client matches this form's slug.
+ * Check against resource_access for comfort.
  * If user has a role, will add the currentUser to the request.
  *
  * @param roles: role name or array or role names
@@ -58,7 +58,7 @@ const hasRole = (roles) => {
   }
 
   const rolecheck = (token, request) => {
-    let result = roles.some(r => token.hasRole(`${RESOURCE_ACCESS}:${r}`));
+    const result = roles.some(r => token.hasRole(`${RESOURCE_ACCESS}:${r}`));
     if (result) request.currentUser = getCurrentUserFromToken(token);
     return result;
   };

--- a/app/src/forms/form/middleware/index.js
+++ b/app/src/forms/form/middleware/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   dataErrors: require('./dataErrors'),
-  ...require('./searchParameters')
+  ...require('./searchParameters'),
+  ...require('./auth')
 };

--- a/app/src/forms/minesattestations/routes.js
+++ b/app/src/forms/minesattestations/routes.js
@@ -7,7 +7,7 @@ routes.get('/', async (req, res, next) => {
   await controller.read(req, res, next);
 });
 
-routes.post('/', async (req, res, next) => {
+routes.post('/', middleware.hasRole(['admin']), async (req, res, next) => {
   await controller.create(req, res, next);
 });
 
@@ -19,11 +19,11 @@ routes.get('/current/statusCodes', async (req, res, next) => {
   await controller.readCurrentStatusCodes(req, res, next);
 });
 
-routes.put('/current/statusCodes', middleware.currentUser, async (req, res, next) => {
+routes.put('/current/statusCodes', middleware.hasRole(['editor']), async (req, res, next) => {
   await controller.updateCurrentStatusCodes(req, res, next);
 });
 
-routes.get('/submissions', middleware.submissionSearch, async (req, res, next) => {
+routes.get('/submissions', middleware.hasRole(['viewer']), middleware.submissionSearch, async (req, res, next) => {
   await controller.searchSubmissions(req, res, next);
 });
 
@@ -31,7 +31,7 @@ routes.post('/submissions', middleware.currentUser, async (req, res, next) => {
   await controller.createSubmission(req, res, next);
 });
 
-routes.put('/submissions/:submissionId', middleware.currentUser, async (req, res, next) => {
+routes.put('/submissions/:submissionId', middleware.hasRole(['editor']), async (req, res, next) => {
   await controller.updateSubmission(req, res, next);
 });
 
@@ -39,27 +39,27 @@ routes.get('/submissions/:submissionId', async (req, res, next) => {
   await controller.readSubmission(req, res, next);
 });
 
-routes.post('/submissions/:submissionId/statuses', middleware.currentUser, async (req, res, next) => {
+routes.post('/submissions/:submissionId/statuses', middleware.hasRole(['editor']), async (req, res, next) => {
   await controller.createSubmissionStatus(req, res, next);
 });
 
-routes.get('/submissions/:submissionId/statuses', async (req, res, next) => {
+routes.get('/submissions/:submissionId/statuses', middleware.hasRole(['editor']), async (req, res, next) => {
   await controller.readSubmissionStatuses(req, res, next);
 });
 
-routes.post('/submissions/:submissionId/statuses/:statusId/notes', middleware.currentUser, async (req, res, next) => {
+routes.post('/submissions/:submissionId/statuses/:statusId/notes', middleware.hasRole(['editor', 'reviewer']), async (req, res, next) => {
   await controller.createSubmissionStatusNote(req, res, next);
 });
 
-routes.get('/submissions/:submissionId/statuses/:statusId/notes', async (req, res, next) => {
+routes.get('/submissions/:submissionId/statuses/:statusId/notes', middleware.hasRole(['viewer']), async (req, res, next) => {
   await controller.readSubmissionStatusNotes(req, res, next);
 });
 
-routes.post('/submissions/:submissionId/notes', middleware.currentUser, async (req, res, next) => {
+routes.post('/submissions/:submissionId/notes', middleware.hasRole(['editor', 'reviewer']), async (req, res, next) => {
   await controller.createSubmissionNote(req, res, next);
 });
 
-routes.get('/submissions/:submissionId/notes', async (req, res, next) => {
+routes.get('/submissions/:submissionId/notes', middleware.hasRole(['viewer']), async (req, res, next) => {
   await controller.readSubmissionNotes(req, res, next);
 });
 


### PR DESCRIPTION
Add form level authorization.
Client for form must be in keycloak, must be part of comfort scope.
Ability to check against a list of roles per route.

Will provide the keycloak setup later.
comfort-minesattestations client (not enabled, just a role container for resource_access).
4 roles: admin, editor, reviewer, viewer.
Check the environment for comfort-minesattestations, check the groups, and check the comfort scope (note it includes the attestations roles).
We are all in the admin group and it has all the roles.

We can discuss what roles we want and what API calls to lock down later (before migrating to test).

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

Do not promote to test until roles have been confirmed and migrated.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->