### PR TITLE
Convert form store module to be lazy-loaded

### DIFF
--- a/app/frontend/src/store/index.js
+++ b/app/frontend/src/store/index.js
@@ -1,12 +1,10 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 
-import form from '@/store/modules/minesAttestations/minesAttestationsForm.js';
-
 Vue.use(Vuex);
 
 export default new Vuex.Store({
-  modules: { form },
+  modules: {},
   state: {},
   mutations: {},
   actions: {}

--- a/app/frontend/src/views/MinesAttestations.vue
+++ b/app/frontend/src/views/MinesAttestations.vue
@@ -9,11 +9,21 @@
 
 <script>
 import AdminNavBar from '@/components/minesattestations/admin/AdminNavBar.vue';
+import minesattestations from '@/store/modules/minesAttestations/minesAttestationsForm.js';
 
 export default {
   name: 'MinesAttestations',
   components: {
     AdminNavBar
+  },
+  beforeDestroy() {
+    this.$store.unregisterModule('form');
+  },
+  created() {
+    if(this.$store.hasModule('form')) {
+      this.$store.unregisterModule('form');
+    }
+    this.$store.registerModule('form', minesattestations);
   }
 };
 </script>

--- a/app/frontend/tests/unit/views/MinesAttestations.spec.js
+++ b/app/frontend/tests/unit/views/MinesAttestations.spec.js
@@ -1,5 +1,6 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuetify from 'vuetify';
+import Vuex from 'vuex';
 
 import getRouter from '@/router';
 import MinesAttestations from '@/views/MinesAttestations.vue';
@@ -7,10 +8,17 @@ import MinesAttestations from '@/views/MinesAttestations.vue';
 const localVue = createLocalVue();
 localVue.use(getRouter());
 localVue.use(Vuetify);
+localVue.use(Vuex);
 
 describe('MinesAttestations.vue', () => {
+  let store;
+
+  beforeEach(() => {
+    store = new Vuex.Store();
+  });
+
   it('renders', () => {
-    const wrapper = shallowMount(MinesAttestations, { localVue });
+    const wrapper = shallowMount(MinesAttestations, { localVue, store });
 
     expect(wrapper.html()).toMatch('router-view');
   });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
- Agressively unmounts any pre-existing form modules before mounting on create
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->