### PR TITLE
Initial POC of settings page

### DIFF
--- a/app/frontend/src/components/minesoperatorscreening/admin/settings/SettingItem.vue
+++ b/app/frontend/src/components/minesoperatorscreening/admin/settings/SettingItem.vue
@@ -3,15 +3,17 @@
     <p>
       <strong>Last Updated:</strong>
       {{ updatedAtDisplay }}
+      <br />
+      <strong>Enabled:</strong>
+      {{ item.enabled }}
     </p>
+    <strong>Config:</strong>
     <pre>{{ JSON.stringify(item.config, null, 2) }}</pre>
   </div>
 </template>
 
 <script>
 import moment from 'moment';
-
-//import minesOperatorScreeningService from '@/services/minesOperatorScreeningService';
 
 export default {
   name: 'SettingItem',

--- a/app/frontend/src/components/minesoperatorscreening/admin/settings/SettingItem.vue
+++ b/app/frontend/src/components/minesoperatorscreening/admin/settings/SettingItem.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <p>
+      <strong>Last Updated:</strong>
+      {{ updatedAtDisplay }}
+    </p>
+    <pre>{{ JSON.stringify(item.config, null, 2) }}</pre>
+  </div>
+</template>
+
+<script>
+import moment from 'moment';
+
+//import minesOperatorScreeningService from '@/services/minesOperatorScreeningService';
+
+export default {
+  name: 'SettingItem',
+  props: {
+    item: {
+      required: true,
+      type: Object,
+    }
+  },
+  computed: {
+    updatedAtDisplay() {
+      return `${moment(this.item.updatedAt).format('MMMM D YYYY, h:mm:ss a')}${this.item.updatedBy ? ' - ' + this.item.updatedBy : ''}`;
+    }
+  }
+};
+</script>

--- a/app/frontend/src/components/minesoperatorscreening/admin/settings/SettingsPanel.vue
+++ b/app/frontend/src/components/minesoperatorscreening/admin/settings/SettingsPanel.vue
@@ -1,0 +1,65 @@
+<template>
+  <div>
+    <v-progress-linear indeterminate v-if="gettingSettings" color="primary" class="mb-2" />
+
+    <v-alert v-if="error" type="error" tile dense>{{ error }}</v-alert>
+
+    <div v-if="!gettingSettings">
+      <v-expansion-panels>
+        <v-expansion-panel v-for="item in treeItems" :key="item.name">
+          <v-expansion-panel-header>{{ item.name }}</v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <SettingItem :item="item" />
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </div>
+  </div>
+</template>
+
+<script>
+
+import minesOperatorScreeningService from '@/services/minesOperatorScreeningService';
+import SettingItem from '@/components/minesoperatorscreening/admin/settings/SettingItem.vue';
+
+export default {
+  name: 'SettingsPanel',
+  components: {
+    SettingItem,
+  },
+  data: () => ({
+    error: false,
+    gettingSettings: false,
+    settings: {},
+    treeItems: [],
+  }),
+  methods: {
+    async getSettings() {
+      this.error = '';
+      this.gettingSettings = true;
+      try {
+        const response = await minesOperatorScreeningService.getSettings();
+        this.settings = response.data;
+        this.treeItems = response.data
+          .filter(s => s.enabled);
+      } catch (error) {
+        console.log(`Error occurred getting Settings: ${error}`); // eslint-disable-line no-console
+        this.error = 'Failed to fetch Settings from the Database';
+      } finally {
+        this.gettingSettings = false;
+      }
+    }
+  },
+  created() {
+    this.getSettings();
+  }
+};
+</script>
+
+<style  scoped>
+.v-expansion-panel-header {
+  font-weight: bold;
+  color: #003366 !important;
+  font-size: 1.1em;
+}
+</style>

--- a/app/frontend/src/components/minesoperatorscreening/admin/settings/SettingsPanel.vue
+++ b/app/frontend/src/components/minesoperatorscreening/admin/settings/SettingsPanel.vue
@@ -6,7 +6,7 @@
 
     <div v-if="!gettingSettings">
       <v-expansion-panels>
-        <v-expansion-panel v-for="item in treeItems" :key="item.name">
+        <v-expansion-panel v-for="item in settings" :key="item.name">
           <v-expansion-panel-header>{{ item.name }}</v-expansion-panel-header>
           <v-expansion-panel-content>
             <SettingItem :item="item" />
@@ -25,13 +25,12 @@ import SettingItem from '@/components/minesoperatorscreening/admin/settings/Sett
 export default {
   name: 'SettingsPanel',
   components: {
-    SettingItem,
+    SettingItem
   },
   data: () => ({
     error: false,
     gettingSettings: false,
-    settings: {},
-    treeItems: [],
+    settings: []
   }),
   methods: {
     async getSettings() {
@@ -40,8 +39,6 @@ export default {
       try {
         const response = await minesOperatorScreeningService.getSettings();
         this.settings = response.data;
-        this.treeItems = response.data
-          .filter(s => s.enabled);
       } catch (error) {
         console.log(`Error occurred getting Settings: ${error}`); // eslint-disable-line no-console
         this.error = 'Failed to fetch Settings from the Database';

--- a/app/frontend/src/router/index.js
+++ b/app/frontend/src/router/index.js
@@ -80,6 +80,16 @@ export default function getRouter(basePath = '/') {
             }
           },
           {
+            path: 'admin/settings',
+            name: 'MinesOperatorScreeningSettings',
+            component: () => import(/* webpackChunkName: "mines-attestations-settings" */ '@/views/minesoperatorscreening/Settings.vue'),
+            meta: {
+              hasLogin: true,
+              requiresAuth: true,
+              title: 'Industrial Camps Settings'
+            }
+          },
+          {
             path: 'admin/submission/:submissionId',
             name: 'MinesOperatorScreeningSubmission',
             component: () => import(/* webpackChunkName: "mines-attestations-submission" */ '@/views/minesoperatorscreening/Submission.vue'),

--- a/app/frontend/src/services/minesOperatorScreeningService.js
+++ b/app/frontend/src/services/minesOperatorScreeningService.js
@@ -102,4 +102,13 @@ export default {
   getStatusCodes() {
     return appAxios().get(`${ApiRoutes.MINESOPERATORSCREENING}/current/statusCodes`);
   },
+
+  /**
+   * @function getSettings
+   * Fetch this form's settings
+   * @returns {Promise} An axios response
+   */
+  getSettings() {
+    return appAxios().get(`${ApiRoutes.MINESOPERATORSCREENING}/settings`);
+  },
 };

--- a/app/frontend/src/views/minesoperatorscreening/Settings.vue
+++ b/app/frontend/src/views/minesoperatorscreening/Settings.vue
@@ -1,0 +1,25 @@
+<template>
+  <v-container>
+    <BaseSecure :resource="resource" admin>
+      <h1 class="mb-6">Settings</h1>
+      <SettingsPanel />
+    </BaseSecure>
+  </v-container>
+</template>
+
+<script>
+import { AppClients } from '@/utils/constants';
+import SettingsPanel from '@/components/minesoperatorscreening/admin/settings/SettingsPanel.vue';
+
+export default {
+  name: 'Settings',
+  components: {
+    SettingsPanel
+  },
+  computed: {
+    resource() {
+      return AppClients.MINESOPERATORSCREENING;
+    }
+  }
+};
+</script>

--- a/app/src/forms/minesoperatorscreening/routes.js
+++ b/app/src/forms/minesoperatorscreening/routes.js
@@ -79,15 +79,15 @@ routes.get('/settings', middleware.checkRole(['viewer']), async (req, res, next)
   await controller.allSettings(req, res, next);
 });
 
-routes.post('/settings', middleware.checkRole(['editor']), async (req, res, next) => {
+routes.post('/settings', middleware.checkRole(['admin']), async (req, res, next) => {
   await controller.createSettings(req, res, next);
 });
 
-routes.get('/settings/:name', middleware.checkRole(['editor']), async (req, res, next) => {
+routes.get('/settings/:name', middleware.checkRole(['viewer']), async (req, res, next) => {
   await controller.readSettings(req, res, next);
 });
 
-routes.put('/settings/:name', middleware.checkRole(['editor']), async (req, res, next) => {
+routes.put('/settings/:name', middleware.checkRole(['admin']), async (req, res, next) => {
   await controller.updateSettings(req, res, next);
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Rough cut of a Settings page for the mines attestation. Probably should only be viewed by us.
Has no functionality that would be 'dangerous' to a user, so leaving the permissions for this at comfort-mineoperatorscreening.admin (rather than a global developer role).

Read only, displays config in JSON for now. Can introduce edit functionality here if we want later.

Did not expose page with a navbar item. This is only for operational tasks for now, access via /admin/settings.
https://comfort-dev.pathfinder.gov.bc.ca/pr-52/minesoperatorscreening/admin/settings

Couple thoughts @parc-jason 
- Maybe have a Display Name column in the DB?
- For later, with edit functionality, maybe there's some sets of settings that don't make sense to let admins update? Like the PDF one as it is right now? Could have an 'editable' flag and have ones with that set to false not return to the UI, or be readonly...

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
I tried a treeview for this initially because I always wanted to use one but that thing seems to be 3-quarters-baked in Vuetify, some weird behaviour and requirements for the data setup (needs unique numbered IDs for nodes).