### PR TITLE
Show status created user on hover of date

### DIFF
--- a/app/frontend/src/components/minesoperatorscreening/admin/inspection/StatusTable.vue
+++ b/app/frontend/src/components/minesoperatorscreening/admin/inspection/StatusTable.vue
@@ -12,7 +12,15 @@
       item-key="inspectionStatusId"
       class="status-table"
     >
-      <template v-slot:item.createdAt="{ item }">{{ formatDateTime(item.createdAt) }}</template>
+      <template v-slot:item.createdAt="{ item }">
+        <v-tooltip bottom :disabled="item.code.toUpperCase() === 'SUBMITTED'">
+          <template v-slot:activator="{ on }">
+            <span v-on="on">{{ formatDateTime(item.createdAt) }}</span>
+          </template>
+          <span>Status updated by {{ item.createdBy }}</span>
+        </v-tooltip>
+      </template>
+
       <template v-slot:item.actionDate="{ item }">{{ formatDate(item.actionDate) }}</template>
     </v-data-table>
   </v-container>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Minor feature I'd had in a stash I forgot to implement earlier.
In the status history table hover the date the status was changed to show who did it.
Do not show the tooltip on Submitted (since it's "public")

Business hasn't asked for this yet, so not cluttering UI, but it will be there so they can see if they need to audit it and ask us how.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->