### PR TITLE
Add Team management page

### DIFF
--- a/app/frontend/src/components/common/TeamTable.vue
+++ b/app/frontend/src/components/common/TeamTable.vue
@@ -49,7 +49,13 @@ export default {
       { text: 'Name', align: 'start', value: 'fullname' },
       { text: 'Email', align: 'start', value: 'email' },
       { text: 'Current Role', align: 'start', value: 'currentRole' },
-      { text: 'New Role', align: 'end', value: 'newRole', sortable: false }
+      {
+        text: 'New Role',
+        align: 'end',
+        value: 'newRole',
+        filterable: false,
+        sortable: false
+      }
     ],
     alertMessage: '',
     alertShow: false,

--- a/app/frontend/src/components/common/TeamTable.vue
+++ b/app/frontend/src/components/common/TeamTable.vue
@@ -1,0 +1,110 @@
+<template>
+  <div>
+    <!-- search input -->
+    <div class="team-search mt-6 mt-sm-0">
+      <v-text-field
+        v-model="search"
+        append-icon="mdi-magnify"
+        label="Search"
+        single-line
+        hide-details
+        class="pb-5"
+      />
+    </div>
+    <!-- table alert -->
+    <v-alert v-if="showAlert" :type="alertType" tile dense>{{ alertMessage }}</v-alert>
+    <!-- table header -->
+    <v-data-table
+      class="team-table"
+      :headers="headers"
+      :items="submissions"
+      :items-per-page="10"
+      :search="search"
+      :loading="loading"
+      loading-text="Loading... Please wait"
+      item-key="confirmationId"
+    >
+      <template v-slot:item.newRole="{ item }">
+        Dropdown TBD {{ item }}
+      </template>
+    </v-data-table>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TeamTable',
+  computed: {
+    formName() {
+      return this.$route.path.split('/')[1];
+    }
+  },
+  data: () => ({
+    search: '',
+    headers: [
+      { text: 'ID', value: 'id' },
+      { text: 'Username', align: 'start', value: 'username' },
+      { text: 'Name', align: 'start', value: 'fullname' },
+      { text: 'Email', align: 'start', value: 'email' },
+      { text: 'Current Role', align: 'start', value: 'currentRole' },
+      { text: 'New Role', value: 'newRole', sortable: false }
+    ],
+    roles: [],
+    users: [],
+    loading: true,
+    showAlert: false,
+    alertType: null,
+    alertMessage: ''
+  }),
+  methods: {
+    getData() {
+      this.loading = false;
+    },
+    showTableAlert(type, msg) {
+      this.showAlert = true;
+      this.alertType = type;
+      this.alertMessage = msg;
+      this.loading = false;
+    }
+  },
+  mounted() {
+    this.getData();
+  }
+};
+</script>
+
+<style scoped>
+.team-search {
+  width: 100%;
+}
+@media (min-width: 600px) {
+  .team-search {
+    max-width: 20em;
+    float: right;
+  }
+}
+@media (max-width: 599px) {
+  .team-search {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+}
+
+.team-table {
+  clear: both;
+}
+@media (max-width: 1263px) {
+  .team-table >>> th {
+    vertical-align: top;
+  }
+}
+
+.team-table >>> tbody tr:nth-of-type(odd) {
+  background-color: #f5f5f5;
+}
+.team-table >>> thead tr th {
+  font-weight: normal;
+  color: #003366 !important;
+  font-size: 1.1em;
+}
+</style>

--- a/app/frontend/src/components/minesoperatorscreening/admin/AdminNavBar.vue
+++ b/app/frontend/src/components/minesoperatorscreening/admin/AdminNavBar.vue
@@ -8,17 +8,37 @@
         <li>
           <router-link :to="{ name: 'MinesOperatorScreeningDashboards' }">Dashboards</router-link>
         </li>
+        <li v-if="isAdmin">
+          <router-link :to="{ name: 'MinesOperatorScreeningTeam' }">Team</router-link>
+        </li>
       </ul>
     </div>
   </nav>
 </template>
 
 <script>
+// TODO: Consider way of converting this into a common component
+import { mapGetters } from 'vuex';
+
+import { AppRoles } from '@/utils/constants';
+
 export default {
   name: 'AdminNavBar',
   computed: {
+    ...mapGetters('auth', ['hasResourceRoles']),
     isAdminPage() {
       return this.$route.path.match(/\/admin/g);
+    }
+  },
+  methods: {
+    isAdmin() {
+      return this.hasResourceRoles(this.resource, AppRoles.ADMIN);
+    }
+  },
+  props: {
+    resource: {
+      type: String,
+      required: true
     }
   }
 };

--- a/app/frontend/src/router/comfort.js
+++ b/app/frontend/src/router/comfort.js
@@ -1,0 +1,26 @@
+/**
+ * Core Comfort Application Routes
+ */
+export default [
+  {
+    path: '/',
+    redirect: { name: 'Home' }
+  },
+  {
+    path: '/home',
+    name: 'Home',
+    component: () => import(/* webpackChunkName: "home" */ '@/views/Home.vue'),
+    meta: {
+      hasLogin: true
+    }
+  },
+  {
+    path: '/404',
+    alias: '*',
+    name: 'NotFound',
+    component: () => import(/* webpackChunkName: "not-found" */ '@/views/NotFound.vue'),
+    meta: {
+      hasLogin: true
+    }
+  }
+];

--- a/app/frontend/src/router/index.js
+++ b/app/frontend/src/router/index.js
@@ -2,6 +2,9 @@ import NProgress from 'nprogress';
 import Vue from 'vue';
 import VueRouter from 'vue-router';
 
+import comfort from './comfort';
+import minesOperatorScreening from './minesOperatorScreening';
+
 Vue.use(VueRouter);
 
 let isFirstTransition = true;
@@ -16,91 +19,8 @@ export default function getRouter(basePath = '/') {
     base: basePath,
     mode: 'history',
     routes: [
-      {
-        path: '/',
-        redirect: { name: 'Home' }
-      },
-      {
-        path: '/home',
-        name: 'Home',
-        component: () => import(/* webpackChunkName: "home" */ '@/views/Home.vue'),
-        meta: {
-          hasLogin: true
-        }
-      },
-      {
-        path: '/minesoperatorscreening',
-        component: () => import(/* webpackChunkName: "minesoperatorscreening" */ '@/views/MinesOperatorScreening.vue'),
-        children: [
-          {
-            path: '',
-            name: 'MinesOperatorScreeningForm',
-            component: () => import(/* webpackChunkName: "minesoperatorscreening-form" */ '@/views/minesoperatorscreening/Root.vue'),
-            meta: {
-              title: 'Industrial Camps'
-            }
-          },
-          {
-            path: 'admin',
-            name: 'MinesOperatorScreeningAdmin',
-            component: () => import(/* webpackChunkName: "minesoperatorscreening-admin" */ '@/views/minesoperatorscreening/Admin.vue'),
-            meta: {
-              hasLogin: true,
-              requiresAuth: true,
-              title: 'Industrial Camps Admin'
-            }
-          },
-          {
-            path: 'admin/dashboard',
-            name: 'MinesOperatorScreeningDashboards',
-            component: () => import(/* webpackChunkName: "minesoperatorscreening-dashboard" */ '@/views/minesoperatorscreening/Dashboards.vue'),
-            meta: {
-              hasLogin: true,
-              requiresAuth: true,
-              title: 'Industrial Camps Admin'
-            }
-          },
-          {
-            path: 'review/:submissionId',
-            name: 'MinesOperatorScreeningReview',
-            component: () => import(/* webpackChunkName: "minesoperatorscreening-review" */ '@/views/minesoperatorscreening/Review.vue'),
-            props: true,
-            meta: {
-              title: 'Industrial Camps Submission Review'
-            }
-          },
-          {
-            path: 'admin/settings',
-            name: 'MinesOperatorScreeningSettings',
-            component: () => import(/* webpackChunkName: "minesoperatorscreening-settings" */ '@/views/minesoperatorscreening/Settings.vue'),
-            meta: {
-              hasLogin: true,
-              requiresAuth: true,
-              title: 'Industrial Camps Settings'
-            }
-          },
-          {
-            path: 'admin/submission/:submissionId',
-            name: 'MinesOperatorScreeningSubmission',
-            component: () => import(/* webpackChunkName: "minesoperatorscreening-submission" */ '@/views/minesoperatorscreening/Submission.vue'),
-            props: true,
-            meta: {
-              hasLogin: true,
-              requiresAuth: true,
-              title: 'Industrial Camps Submission'
-            }
-          }
-        ]
-      },
-      {
-        path: '/404',
-        alias: '*',
-        name: 'NotFound',
-        component: () => import(/* webpackChunkName: "not-found" */ '@/views/NotFound.vue'),
-        meta: {
-          hasLogin: true
-        }
-      }
+      ...comfort,
+      ...minesOperatorScreening
     ]
   });
 

--- a/app/frontend/src/router/minesOperatorScreening.js
+++ b/app/frontend/src/router/minesOperatorScreening.js
@@ -1,0 +1,79 @@
+/**
+ * Mines Operator Screening Form Routes
+ */
+export default [
+  {
+    path: '/minesoperatorscreening',
+    component: () => import(/* webpackChunkName: "minesoperatorscreening" */ '@/views/MinesOperatorScreening.vue'),
+    children: [
+      {
+        path: '',
+        name: 'MinesOperatorScreeningForm',
+        component: () => import(/* webpackChunkName: "minesoperatorscreening-form" */ '@/views/minesoperatorscreening/Root.vue'),
+        meta: {
+          title: 'Industrial Camps'
+        }
+      },
+      {
+        path: 'admin',
+        name: 'MinesOperatorScreeningAdmin',
+        component: () => import(/* webpackChunkName: "minesoperatorscreening-admin" */ '@/views/minesoperatorscreening/Admin.vue'),
+        meta: {
+          hasLogin: true,
+          requiresAuth: true,
+          title: 'Industrial Camps Admin'
+        }
+      },
+      {
+        path: 'admin/dashboard',
+        name: 'MinesOperatorScreeningDashboards',
+        component: () => import(/* webpackChunkName: "minesoperatorscreening-dashboard" */ '@/views/minesoperatorscreening/Dashboards.vue'),
+        meta: {
+          hasLogin: true,
+          requiresAuth: true,
+          title: 'Industrial Camps Admin'
+        }
+      },
+      {
+        path: 'admin/settings',
+        name: 'MinesOperatorScreeningSettings',
+        component: () => import(/* webpackChunkName: "minesoperatorscreening-settings" */ '@/views/minesoperatorscreening/Settings.vue'),
+        meta: {
+          hasLogin: true,
+          requiresAuth: true,
+          title: 'Industrial Camps Settings'
+        }
+      },
+      {
+        path: 'admin/submission/:submissionId',
+        name: 'MinesOperatorScreeningSubmission',
+        component: () => import(/* webpackChunkName: "minesoperatorscreening-submission" */ '@/views/minesoperatorscreening/Submission.vue'),
+        props: true,
+        meta: {
+          hasLogin: true,
+          requiresAuth: true,
+          title: 'Industrial Camps Submission'
+        }
+      },
+      {
+        path: 'admin/team',
+        name: 'MinesOperatorScreeningTeam',
+        component: () => import(/* webpackChunkName: "minesoperatorscreening-team" */ '@/views/minesoperatorscreening/Team.vue'),
+        meta: {
+          hasLogin: true,
+          requiresAuth: true,
+          title: 'Industrial Camps Team Management'
+        }
+      },
+      {
+        path: 'review/:submissionId',
+        name: 'MinesOperatorScreeningReview',
+        component: () => import(/* webpackChunkName: "minesoperatorscreening-review" */ '@/views/minesoperatorscreening/Review.vue'),
+        props: true,
+        meta: {
+          title: 'Industrial Camps Submission Review'
+        }
+      },
+    ]
+  }
+];

--- a/app/frontend/src/services/commonFormService.js
+++ b/app/frontend/src/services/commonFormService.js
@@ -5,10 +5,26 @@ export default {
    * @function getTeamRoles
    * Fetches a list of valid team roles for `form`.
    * @param {string} form The form name
+   * @param {boolean} [users=false] Populate response with users
    * @returns {Promise} An axios response
    */
-  getTeamRoles(form) {
-    return appAxios().get(`${form}/team/roles`);
+  getTeamRoles(form, users = false) {
+    const params = {};
+    if (users) params.users = true;
+    return appAxios().get(`${form}/team/roles`, { params });
+  },
+
+  /**
+   * @function getTeamUsers
+   * Fetches a list of valid team roles for `form`.
+   * @param {string} form The form name
+   * @param {boolean} [roles=false] Populate response with roles
+   * @returns {Promise} An axios response
+   */
+  getTeamUsers(form, roles = false) {
+    const params = {};
+    if (roles) params.roles = true;
+    return appAxios().get(`${form}/team/users`, { params });
   },
 
   /**

--- a/app/frontend/src/store/modules/auth.js
+++ b/app/frontend/src/store/modules/auth.js
@@ -24,7 +24,7 @@ export default {
       if (!getters.authenticated) return false;
       if (!roles.length) return true; // No roles to check against
 
-      if (getters.resourceAccess[resource]) {
+      if (getters.resourceAccess && getters.resourceAccess[resource]) {
         return hasRoles(getters.resourceAccess[resource].roles, roles);
       }
       return false; // There are roles to check, but nothing in token to check against

--- a/app/frontend/src/views/MinesOperatorScreening.vue
+++ b/app/frontend/src/views/MinesOperatorScreening.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <AdminNavBar />
+    <AdminNavBar :resource="resource" />
     <transition name="component-fade" mode="out-in">
       <router-view />
     </transition>
@@ -10,6 +10,7 @@
 <script>
 import AdminNavBar from '@/components/minesoperatorscreening/admin/AdminNavBar.vue';
 import form from '@/store/modules/minesoperatorscreening/minesOperatorScreeningForm.js';
+import { AppClients } from '@/utils/constants';
 
 export default {
   name: 'MinesOperatorScreening',
@@ -18,6 +19,11 @@ export default {
   },
   beforeDestroy() {
     this.$store.unregisterModule('form');
+  },
+  computed: {
+    resource() {
+      return AppClients.MINESOPERATORSCREENING;
+    }
   },
   created() {
     if(this.$store.hasModule('form')) {

--- a/app/frontend/src/views/minesoperatorscreening/Team.vue
+++ b/app/frontend/src/views/minesoperatorscreening/Team.vue
@@ -2,15 +2,20 @@
   <v-container>
     <BaseSecure :resource="resource" admin>
       <h1 class="mb-6">Team Management</h1>
+      <TeamTable />
     </BaseSecure>
   </v-container>
 </template>
 
 <script>
 import { AppClients } from '@/utils/constants';
+import TeamTable from '@/components/common/TeamTable';
 
 export default {
   name: 'Team',
+  components: {
+    TeamTable
+  },
   computed: {
     resource() {
       return AppClients.MINESOPERATORSCREENING;

--- a/app/frontend/src/views/minesoperatorscreening/Team.vue
+++ b/app/frontend/src/views/minesoperatorscreening/Team.vue
@@ -2,7 +2,7 @@
   <v-container>
     <BaseSecure :resource="resource" admin>
       <h1 class="mb-6">Team Management</h1>
-      <TeamTable />
+      <TeamTable :formName="formName" />
     </BaseSecure>
   </v-container>
 </template>
@@ -17,6 +17,9 @@ export default {
     TeamTable
   },
   computed: {
+    formName() {
+      return this.$route.path.split('/')[1];
+    },
     resource() {
       return AppClients.MINESOPERATORSCREENING;
     }

--- a/app/frontend/src/views/minesoperatorscreening/Team.vue
+++ b/app/frontend/src/views/minesoperatorscreening/Team.vue
@@ -1,0 +1,20 @@
+<template>
+  <v-container>
+    <BaseSecure :resource="resource" admin>
+      <h1 class="mb-6">Team Management</h1>
+    </BaseSecure>
+  </v-container>
+</template>
+
+<script>
+import { AppClients } from '@/utils/constants';
+
+export default {
+  name: 'Team',
+  computed: {
+    resource() {
+      return AppClients.MINESOPERATORSCREENING;
+    }
+  }
+};
+</script>

--- a/app/frontend/tests/unit/router/comfort.spec.js
+++ b/app/frontend/tests/unit/router/comfort.spec.js
@@ -1,0 +1,22 @@
+import routes from '@/router/comfort';
+
+describe('Routes > Comfort ', () => {
+  it('has the correct number of routes', () => {
+    expect(routes).toHaveLength(3);
+  });
+
+  it('has the expected routes and metadata', () => {
+    expect(routes).toContainEqual(expect.objectContaining({
+      name: 'Home',
+      meta: {
+        hasLogin: true
+      }
+    }));
+    expect(routes).toContainEqual(expect.objectContaining({
+      name: 'NotFound',
+      meta: {
+        hasLogin: true
+      }
+    }));
+  });
+});

--- a/app/frontend/tests/unit/router/index.spec.js
+++ b/app/frontend/tests/unit/router/index.spec.js
@@ -1,16 +1,27 @@
 import getRouter from '@/router';
 
 describe('Router', () => {
-  const router = getRouter();
-  const routes = router.options.routes;
+  let router;
 
-  it('has the correct number of routes', () => {
-    expect(routes).toHaveLength(4);
+  beforeEach(() => {
+    router = getRouter();
   });
 
-  it('has the expected routes', () => {
-    const routeSet = new Set(routes);
-    expect(routeSet).toContainEqual(expect.objectContaining({ name: 'Home' }));
-    expect(routeSet).toContainEqual(expect.objectContaining({ name: 'NotFound' }));
+  it('defaults to / path when unspecified', () => {
+    expect(router.options.base).toMatch('/');
+  });
+
+  it('uses the specified path parameter', () => {
+    const path = '/test';
+    router = getRouter(path);
+    expect(router.options.base).toMatch(path);
+  });
+
+  it('is in history mode', () => {
+    expect(router.options.mode).toMatch('history');
+  });
+
+  it('has the correct number of route entries', () => {
+    expect(router.options.routes).toHaveLength(4);
   });
 });

--- a/app/frontend/tests/unit/router/minesOperatorScreening.spec.js
+++ b/app/frontend/tests/unit/router/minesOperatorScreening.spec.js
@@ -1,0 +1,65 @@
+import routes from '@/router/minesOperatorScreening';
+
+describe('Routes > MinesOperatorScreening ', () => {
+  it('has the correct number of routes', () => {
+    expect(routes).toHaveLength(1);
+    expect(routes[0].children).toHaveLength(7);
+  });
+
+  it('has the expected routes and metadata', () => {
+    expect(routes[0].children).toContainEqual(expect.objectContaining({
+      name: 'MinesOperatorScreeningForm',
+      meta: {
+        title: 'Industrial Camps'
+      }
+    }));
+    expect(routes[0].children).toContainEqual(expect.objectContaining({
+      name: 'MinesOperatorScreeningAdmin',
+      meta: {
+        hasLogin: true,
+        requiresAuth: true,
+        title: 'Industrial Camps Admin'
+      }
+    }));
+    expect(routes[0].children).toContainEqual(expect.objectContaining({
+      name: 'MinesOperatorScreeningDashboards',
+      meta: {
+        hasLogin: true,
+        requiresAuth: true,
+        title: 'Industrial Camps Admin'
+      }
+    }));
+    expect(routes[0].children).toContainEqual(expect.objectContaining({
+      name: 'MinesOperatorScreeningSettings',
+      meta: {
+        hasLogin: true,
+        requiresAuth: true,
+        title: 'Industrial Camps Settings'
+      }
+    }));
+    expect(routes[0].children).toContainEqual(expect.objectContaining({
+      name: 'MinesOperatorScreeningSubmission',
+      props: true,
+      meta: {
+        hasLogin: true,
+        requiresAuth: true,
+        title: 'Industrial Camps Submission'
+      }
+    }));
+    expect(routes[0].children).toContainEqual(expect.objectContaining({
+      name: 'MinesOperatorScreeningTeam',
+      meta: {
+        hasLogin: true,
+        requiresAuth: true,
+        title: 'Industrial Camps Team Management'
+      }
+    }));
+    expect(routes[0].children).toContainEqual(expect.objectContaining({
+      name: 'MinesOperatorScreeningReview',
+      props: true,
+      meta: {
+        title: 'Industrial Camps Submission Review'
+      }
+    }));
+  });
+});

--- a/app/frontend/tests/unit/services/commonFormService.spec.js
+++ b/app/frontend/tests/unit/services/commonFormService.spec.js
@@ -15,34 +15,78 @@ jest.mock('@/services/interceptors', () => {
 });
 
 describe('getTeamRoles', () => {
+  const endpoint = `${form}/team/roles`;
+
   beforeEach(() => {
     mockAxios.reset();
   });
 
   it('calls team roles endpoint', async () => {
-    mockAxios.onGet(`${form}/team/roles`).reply(200);
+    mockAxios.onGet(endpoint).reply(200);
 
     const result = await commonFormService.getTeamRoles(form);
     expect(result).toBeTruthy();
-    expect(mockAxios.history.get.length).toBe(1);
+    expect(mockAxios.history.get).toHaveLength(1);
+    expect(Object.keys(mockAxios.history.get[0].params)).toHaveLength(0);
+  });
+
+  it('calls team roles endpoint with users', async () => {
+    mockAxios.onGet(endpoint).reply(200);
+
+    const result = await commonFormService.getTeamRoles(form, true);
+    expect(result).toBeTruthy();
+    expect(mockAxios.history.get).toHaveLength(1);
+    expect(Object.keys(mockAxios.history.get[0].params)).toHaveLength(1);
+    expect(mockAxios.history.get[0].params.users).toBeTruthy();
+  });
+});
+
+describe('getTeamUsers', () => {
+  const endpoint = `${form}/team/users`;
+
+  beforeEach(() => {
+    mockAxios.reset();
+  });
+
+  it('calls team users endpoint', async () => {
+    mockAxios.onGet(endpoint).reply(200);
+
+    const result = await commonFormService.getTeamUsers(form);
+    expect(result).toBeTruthy();
+    expect(mockAxios.history.get).toHaveLength(1);
+    expect(Object.keys(mockAxios.history.get[0].params)).toHaveLength(0);
+  });
+
+  it('calls team users endpoint with roles', async () => {
+    mockAxios.onGet(endpoint).reply(200);
+
+    const result = await commonFormService.getTeamUsers(form, true);
+    expect(result).toBeTruthy();
+    expect(mockAxios.history.get).toHaveLength(1);
+    expect(Object.keys(mockAxios.history.get[0].params)).toHaveLength(1);
+    expect(mockAxios.history.get[0].params.roles).toBeTruthy();
   });
 });
 
 describe('requestTeamAccess', () => {
+  const endpoint = `${form}/team/access`;
+
   beforeEach(() => {
     mockAxios.reset();
   });
 
   it('calls team endpoint', async () => {
-    mockAxios.onPost(`${form}/team/access`).reply(201);
+    mockAxios.onPost(endpoint).reply(201);
 
     const result = await commonFormService.requestTeamAccess(form);
     expect(result).toBeTruthy();
-    expect(mockAxios.history.post.length).toBe(1);
+    expect(mockAxios.history.post).toHaveLength(1);
   });
 });
 
 describe('requestReceiptEmail', () => {
+  const endpoint = `${form}/submissions/email`;
+
   beforeEach(() => {
     mockAxios.reset();
   });
@@ -52,11 +96,11 @@ describe('requestReceiptEmail', () => {
       submissionId: 'TEST',
       to: 'test@example.com'
     };
-    mockAxios.onPost(`${form}/submissions/email`).reply(201, data);
+    mockAxios.onPost(endpoint).reply(201, data);
 
     const result = await commonFormService.requestReceiptEmail(form, data);
     expect(result).toBeTruthy();
     expect(result.data).toEqual(data);
-    expect(mockAxios.history.post.length).toBe(1);
+    expect(mockAxios.history.post).toHaveLength(1);
   });
 });

--- a/app/frontend/tests/unit/store/modules/auth.getters.spec.js
+++ b/app/frontend/tests/unit/store/modules/auth.getters.spec.js
@@ -96,7 +96,29 @@ describe('auth getters', () => {
     expect(store.getters.hasResourceRoles(AppClients.APP, roles)).toBeTruthy();
   });
 
-  it('hasResourceRoles should return false when resource does not exist', () => {
+  it('hasResourceRoles should return false when resource_access is undefined', () => {
+    authenticated = true;
+    roles = [AppRoles.ADMIN];
+
+    // TODO: Find better way to set up keycloak object mock without deleting first
+    delete Vue.prototype.$keycloak;
+    Object.defineProperty(Vue.prototype, '$keycloak', {
+      configurable: true, // Needed to allow deletions later
+      get() {
+        return {
+          authenticated: authenticated,
+          tokenParsed: {
+            realm_access: {},
+          }
+        };
+      }
+    });
+
+    expect(store.getters.authenticated).toBeTruthy();
+    expect(store.getters.hasResourceRoles(AppClients.APP, roles)).toBeFalsy();
+  });
+
+  it('hasResourceRoles should return false when a specific resource does not exist', () => {
     authenticated = true;
     roles = [AppRoles.ADMIN];
 


### PR DESCRIPTION
# Description

This PR begins implementing the API introduced in PR #68. This introduces the Team management admin page which can allow a form administrator to see what users have access to the form. This PR does not have the ability to update a user yet - this will be added in a subsequent PR.

**Other Changes:**
- Refactor router to be split up based on logical form domains

[SHOWCASE-1209](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1209)

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->