### PR TITLE
Bugfix Registered Company lookup does not work when entering a non-alpha character

### DIFF
--- a/app/frontend/src/components/common/CityLookup.vue
+++ b/app/frontend/src/components/common/CityLookup.vue
@@ -124,7 +124,7 @@ export default {
       try {
         const response = await axios.get(`${this.apiURL()}/addresses.json`, {
           params: {
-            addressString: encodeURIComponent(val),
+            addressString: val,
             autocomplete: true,
             brief: true,
             echo: false,

--- a/app/frontend/src/components/common/OrgBookSearch.vue
+++ b/app/frontend/src/components/common/OrgBookSearch.vue
@@ -103,7 +103,7 @@ export default {
           params: {
             inactive: false,
             latest: true,
-            q: encodeURIComponent(val),
+            q: val,
             revoked: false
           }
         });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
Bugfix Registered Company lookup does not work when entering a non-alpha character
- Axios already does uri encoding - don't need it (remnant from fetch)
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-1354](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1354)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This also affects City Lookup - applied fix there as well as it's the same type of bug.