### PR TITLE
Change v-content to v-main due to deprecation

### DIFF
--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -2,11 +2,11 @@
   <v-app>
     <BCGovHeader />
 
-    <v-content>
+    <v-main>
       <transition name="component-fade" mode="out-in">
         <router-view />
       </transition>
-    </v-content>
+    </v-main>
 
     <BCGovFooter />
   </v-app>

--- a/app/frontend/tests/unit/App.spec.js
+++ b/app/frontend/tests/unit/App.spec.js
@@ -16,6 +16,6 @@ describe('Secure.vue', () => {
       stubs: ['BaseSecure', 'BCGovFooter', 'BCGovHeader', 'router-view']
     });
 
-    expect(wrapper.text()).toMatch('');
+    expect(wrapper.html()).toMatch('v-main');
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
Vuetify is deprecating v-content and wants v-main to be used instead.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->