### PR TITLE
remove token refresh process for keycloak admin client

### DIFF
--- a/app/src/components/keycloakAdminService.js
+++ b/app/src/components/keycloakAdminService.js
@@ -5,19 +5,6 @@ const Problem = require('api-problem');
 
 const errorToProblem = require('./errorToProblem');
 
-const refreshToken = (svc) => setInterval(async () => {
-  // just in case we didn't go through the initialization phase.
-  await svc.initialize(false);
-  try {
-    const refreshToken = svc._tokenSet.refresh_token;
-    svc._tokenSet = await svc._client.refresh(refreshToken);
-    svc._kcAdminClient.setAccessToken(svc._tokenSet.access_token);
-  } catch (e) {
-    log.error('KeycloakAdminService.refreshToken', `Error refreshing token. Re-initializing/authorizing admin client. ${e.message}`);
-    await svc.initialize(true);
-  }
-}, 58 * 1000); // 58 seconds
-
 const trimUserData = (data, nullDataValue = []) => {
   if (!data) return nullDataValue;
 
@@ -118,7 +105,6 @@ class KeycloakAdminService {
         return false;
       }
       this._initialized = true;
-      refreshToken(this); // start the token auto-refresh
     }
     return this._initialized;
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

authentication between our app and keycloak admin service is a client_credentials grant and doesn't require a refresh token.
I'm not sure but I think we remove that requirement like this. 

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->